### PR TITLE
added citation data

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,12 @@
+{
+   "creators": [
+      {
+         "name": "Zapata, Felipe"
+      }
+   ], 
+   "description": "An Ansible playbook to use GitHub Actions with your own hardware.", 
+   "license": {
+      "id": "Apache-2.0"
+   }, 
+   "title": "linux_actions_runner"
+}

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,15 @@
+# YAML 1.2
+---
+abstract: "An Ansible playbook to use GitHub Actions with your own hardware."
+authors: 
+  -
+    family-names: Zapata
+    given-names: Felipe
+cff-version: "1.1.0"
+doi: "10.0000/FIXME"
+keywords: 
+license: "Apache-2.0"
+message: "If you use this software, please cite it using these metadata."
+repository-code: "https://github.com/NLESC-JCER/linux_actions_runner"
+title: "linux_actions_runner"
+...


### PR DESCRIPTION
This PR adds citation metadata and derived zenodo metadata.

Some things to consider:
- we should add Felipe's orcid if he has one
- the title of the software could be better
- please check if the oneliner abstract is accurate

Felipe should flip the switch on ``NLESC-JCER/linux_actions_runner`` repo here https://zenodo.org/account/settings/github/

Refs #4