### PR TITLE
fix(ubuntu-singularity): add apt-get update to .def

### DIFF
--- a/ubuntu-singularity/github-actions-runner-singularity.def
+++ b/ubuntu-singularity/github-actions-runner-singularity.def
@@ -16,6 +16,7 @@ Stage: build
     export RUNNER_VERSION=2.267.1
     chmod +x /entrypoint.sh
 
+    apt-get update -y
     apt-get install -y --no-install-recommends software-properties-common
     add-apt-repository universe
     add-apt-repository multiverse


### PR DESCRIPTION
To address the issue #148 I added `apt-get update -y` into the `.def` file just before the line that installs `software-properties-common`.

I have tested this fix on singularity v4.1.0 on Ubuntu and the `.sif` file was successfully created.