### PR TITLE
fix(def): add startscript section

### DIFF
--- a/ubuntu-singularity/github-actions-runner-singularity.def
+++ b/ubuntu-singularity/github-actions-runner-singularity.def
@@ -41,3 +41,8 @@ Stage: build
     echo "Container was created $NOW"
     echo "Arguments received: $*"
     exec /bin/bash /entrypoint.sh "$@"
+
+%startscript
+    echo "Container was created $NOW"
+    echo "Arguments received: $*"
+    exec /bin/bash /entrypoint.sh "$@"


### PR DESCRIPTION
Addresses #150 by adding `%startscript` section to `.def` file.

Now when using commands from `ubuntu-singularity/README.md` a runner is created and registered with GitHub, and logs can be inspected with `tail -f [LOG_LOCATION]`. 